### PR TITLE
Default for no phrase (return all)

### DIFF
--- a/R/stars.R
+++ b/R/stars.R
@@ -2,7 +2,7 @@
 #'
 #' Text search GitHub stars
 #'
-#' @param phrase Text string to search for
+#' @param phrase Text string to search for. Defaults to "code"
 #' @param user Name of GitHub user whose stars you want to search. Defaults to
 #' your own profile
 #' @param language Filter results to specified primary repository language
@@ -14,7 +14,7 @@
 #' @return Interactive screen dump of results enabling you to select the best
 #' match and open the corresponding GitHub repository
 #' @export
-stars <- function (phrase = "", user = NULL, language = NULL, ghname = NULL,
+stars <- function (phrase = "code", user = NULL, language = NULL, ghname = NULL,
                    newest_first = TRUE, interactive = TRUE)
 {
     s <- getstars (user, language, ghname, newest_first)

--- a/R/stars.R
+++ b/R/stars.R
@@ -2,7 +2,7 @@
 #'
 #' Text search GitHub stars
 #'
-#' @param phrase Text string to search for. Defaults to "code"
+#' @param phrase Text string to search for. Defaults to returning all stars from a user.
 #' @param user Name of GitHub user whose stars you want to search. Defaults to
 #' your own profile
 #' @param language Filter results to specified primary repository language
@@ -14,10 +14,16 @@
 #' @return Interactive screen dump of results enabling you to select the best
 #' match and open the corresponding GitHub repository
 #' @export
-stars <- function (phrase = "code", user = NULL, language = NULL, ghname = NULL,
+stars <- function (phrase = NULL, user = NULL, language = NULL, ghname = NULL,
                    newest_first = TRUE, interactive = TRUE)
 {
     s <- getstars (user, language, ghname, newest_first)
+    ## return all
+    if (is.null(phrase)) {
+      for (i in seq (nrow (s)))
+        print_repo (s, i)
+      return(invisible(s))
+    }
     repos <- star_search (s, phrase)$repo_names
     ret <- NULL
     if (length (repos) == 0)

--- a/R/stars.R
+++ b/R/stars.R
@@ -2,7 +2,7 @@
 #'
 #' Text search GitHub stars
 #'
-#' @param phrase Text string to search for. Defaults to returning all stars from a user.
+#' @param phrase Text string to search for. Defaults to returning all starred repositories from the specified user
 #' @param user Name of GitHub user whose stars you want to search. Defaults to
 #' your own profile
 #' @param language Filter results to specified primary repository language

--- a/man/stars.Rd
+++ b/man/stars.Rd
@@ -4,18 +4,18 @@
 \alias{stars}
 \title{stars}
 \usage{
-stars(phrase = "", user = NULL, language = NULL, ghname = NULL,
+stars(phrase = "code", user = NULL, language = NULL, ghname = NULL,
   newest_first = TRUE, interactive = TRUE)
 }
 \arguments{
-\item{phrase}{Text string to search for}
+\item{phrase}{Text string to search for. Defaults to "code"}
 
-\item{user}{Name of github user whose stars you want to search. Defaults to
+\item{user}{Name of GitHub user whose stars you want to search. Defaults to
 your own profile}
 
 \item{language}{Filter results to specified primary repository language}
 
-\item{ghname}{Filter results to repos belonging to a specified github name}
+\item{ghname}{Filter results to repos belonging to a specified GitHub name}
 
 \item{newest_first}{Sort by newest stars first}
 
@@ -24,8 +24,8 @@ issue a return object, and exit.}
 }
 \value{
 Interactive screen dump of results enabling you to select the best
-match and open the corresponding github repository
+match and open the corresponding GitHub repository
 }
 \description{
-Text search github stars
+Text search GitHub stars
 }

--- a/man/stars.Rd
+++ b/man/stars.Rd
@@ -4,11 +4,11 @@
 \alias{stars}
 \title{stars}
 \usage{
-stars(phrase = "code", user = NULL, language = NULL, ghname = NULL,
+stars(phrase = NULL, user = NULL, language = NULL, ghname = NULL,
   newest_first = TRUE, interactive = TRUE)
 }
 \arguments{
-\item{phrase}{Text string to search for. Defaults to "code"}
+\item{phrase}{Text string to search for. Defaults to returning all stars from a user.}
 
 \item{user}{Name of GitHub user whose stars you want to search. Defaults to
 your own profile}

--- a/man/stars.Rd
+++ b/man/stars.Rd
@@ -8,7 +8,7 @@ stars(phrase = NULL, user = NULL, language = NULL, ghname = NULL,
   newest_first = TRUE, interactive = TRUE)
 }
 \arguments{
-\item{phrase}{Text string to search for. Defaults to returning all stars from a user.}
+\item{phrase}{Text string to search for. Defaults to returning all starred repositories from the specified user}
 
 \item{user}{Name of GitHub user whose stars you want to search. Defaults to
 your own profile}


### PR DESCRIPTION
I originally thought about using a semi-sensible default for `phrase` but then thought it might be more useful to just return *all* results. I'd certainly use it this way on occasion. Addresses #12.